### PR TITLE
Revert "added extract support to the reindex command"

### DIFF
--- a/src/Zicht/Bundle/SolrBundle/Manager/SolrManager.php
+++ b/src/Zicht/Bundle/SolrBundle/Manager/SolrManager.php
@@ -131,46 +131,6 @@ class SolrManager
         return [$n, $i];
     }
 
-    /**
-     * Extracts as batch.
-     *
-     * @param array $records
-     * @param callable|null $incrementCallback
-     * @param callable|null $errorCallback
-     *
-     * @return array
-     */
-    public function extractBatch($records, $incrementCallback = null, $errorCallback = null)
-    {
-        $n = $i = 0;
-        foreach ($records as $record) {
-            $mapper = $this->getMapper($record);
-            if ($mapper === null) {
-                continue;
-            }
-
-            $i++;
-            try {
-                $extract = new QueryBuilder\Extract();
-                $mapper->extract($extract, $record);
-                $this->client->extract($extract);
-            } catch (\Exception $e) {
-                if ($errorCallback) {
-                    call_user_func($errorCallback, $record, $e);
-                }
-            }
-
-            if ($incrementCallback) {
-                call_user_func($incrementCallback, $n);
-            }
-
-            $n++;
-        }
-        call_user_func($incrementCallback, $n);
-
-        return [$n, $i];
-    }
-
 
     /**
      * Update an entity


### PR DESCRIPTION
This is not inline with the implementation used by the  [Subscriber](https://github.com/zicht/solr-bundle/blob/release/3.2.x/src/Zicht/Bundle/SolrBundle/Manager/Doctrine/Subscriber.php#L89) and can cause different behavior hen a entity is indexed from cli or from web . 

It will also fail when trying to index a entity without a [file](https://github.com/zicht/solr-bundle/blob/release/3.2.x/src/Zicht/Bundle/SolrBundle/Solr/QueryBuilder/Extract.php#L52) and could lead to a incomplete index.
