### PR TITLE
[WIP][BRUGGE-107] This commit refactors the redirect given when translating from POST to GET, previously this behavior would lead to invalid urls such as;

### DIFF
--- a/src/Zicht/Bundle/SolrBundle/Facade/SearchFacade.php
+++ b/src/Zicht/Bundle/SolrBundle/Facade/SearchFacade.php
@@ -5,6 +5,8 @@
  */
 namespace Zicht\Bundle\SolrBundle\Facade;
 
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Zicht\Bundle\BruggeSiteBundle\Exception\RedirectException;
 use Zicht\Bundle\FrameworkExtraBundle\Pager\Pager;
 use Zicht\Bundle\SolrBundle\Solr\Client;
 use Zicht\Bundle\SolrBundle\Solr\QueryBuilder\Select;
@@ -109,7 +111,6 @@ abstract class SearchFacade
         }
     }
 
-
     /**
      * @return Params
      */
@@ -126,11 +127,13 @@ abstract class SearchFacade
     public function redirectPost()
     {
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-            header(sprintf('Location: %s', $this->getPostRedirect($_POST['search'])));
-            exit;
+            throw new RedirectException(
+                new RedirectResponse(
+                    $this->getPostRedirect($_POST['search'])
+                )
+            );
         }
     }
-
 
     /**
      * Returns the GET url based on a POST search.


### PR DESCRIPTION
- /nl/page/xxx

This was because sub requests were being rewritten, and never captured by the exception handler, with the change also made in the exception handler bundle this combination now allows for urls being properly translated.