### PR TITLE
Do not do update after delete in batch update bugfix

### DIFF
--- a/src/Zicht/Bundle/SolrBundle/Manager/SolrManager.php
+++ b/src/Zicht/Bundle/SolrBundle/Manager/SolrManager.php
@@ -73,8 +73,9 @@ class SolrManager
                 try {
                     if ($delete) {
                         $mapper->delete($this->client, $record, $update);
+                    } else {
+                        $mapper->update($this->client, $record, $update);
                     }
-                    $mapper->update($this->client, $record, $update);
                 } catch (\Exception $e) {
                     if ($errorCallback) {
                         call_user_func($errorCallback, $record, $e);


### PR DESCRIPTION
The `\Zicht\Bundle\SolrBundle\Manager\SolrManager::updateBatch()` method has a `bool $delete` parameter that can be set to execute a delete query for the batch of records instead of the default update query. In the code of this method it will check this parameter and add the delete query, but immediately after that it will also still do the update query resulting in the record being added again... :man_facepalming: 