### PR TITLE
Search facade facet meta data calls

### DIFF
--- a/src/Zicht/Bundle/SolrBundle/Facade/SearchFacade.php
+++ b/src/Zicht/Bundle/SolrBundle/Facade/SearchFacade.php
@@ -349,11 +349,11 @@ abstract class SearchFacade
      *
      * @param string $facetName
      * @param mixed $value
-     * @param int $count
-     * @param string $label
+     * @param int|null $count
+     * @param string|null $label
      * @return array
      */
-    public function getFacetMetaData($facetName, $value, $count, $label = null)
+    public function getFacetMetaData($facetName, $value, $count = null, $label = null)
     {
         return array(
             'value'         => $value,


### PR DESCRIPTION
In the same class/file a call to the method is missing the third argument ([SearchFacade.php line 384](../blob/387e6d941a0915ba909a07b12ab1ee1522701e64/src/Zicht/Bundle/SolrBundle/Facade/SearchFacade.php#L384) inside the `decorateHierarchy()` method) resulting in a fatal _Type error_:
> Too few arguments to function Zicht\Bundle\SolrBundle\Facade\SearchFacade::getFacetMetaData(), 2 passed in src/Zicht/Bundle/SolrBundle/Facade/SearchFacade.php on line 384 and at least 3 expected

In another call, `null` is passed as a third argument. Therefor I think the third argument [can have a default value of `null`](26/files) solving this bug.