### PR TITLE
Fix: strip slash-r from synonym list

### DIFF
--- a/src/Zicht/Bundle/SolrBundle/Manager/SynonymManager.php
+++ b/src/Zicht/Bundle/SolrBundle/Manager/SynonymManager.php
@@ -68,7 +68,7 @@ class SynonymManager
      */
     public function addSynonym(Synonym $synonym)
     {
-        $data = explode(PHP_EOL, $synonym->getValue());
+        $data = explode(PHP_EOL, str_replace("\r", '', $synonym->getValue()));
         $request =  $this->client->getHttpClient()->createRequest(
             'PUT',
             sprintf('schema/analysis/synonyms/%s', $synonym->getManaged()),


### PR DESCRIPTION
Within a project I got this in my synonyms JSON. I enter these synonyms in a textarea each on its own line. This results in the line terminator being `\r\n`.

```json
"monkey": [
    "baboon\r",
    "capuchin\r",
    "gorilla\r",
    "macaque\r",
    "orang-utan"
]
```