### PR TITLE
Solr bundle should require Sonata Admin now that it contains "admins"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     ],
     "require": {
         "php": "^5.6|^7",
-        "symfony/symfony": ">=2.1",
+        "sonata-project/admin-bundle": "^3",
+        "symfony/symfony": "^2.3 || ^3.0",
         "guzzlehttp/guzzle": "5.3.*@stable"
     },
     "autoload": {


### PR DESCRIPTION
See:
https://github.com/zicht/solr-bundle/blob/6284ba08623d6960fa62d829144008459bf51176/src/Zicht/Bundle/SolrBundle/Admin/SynonymAdmin.php#L8-L13

Also changed the version constraint on `symfony/symfony` from `>=2.1` to `^2.3 || ^3.0` as [Sonata Admin's 3.0.0 minimum Symfony version is 2.3](https://github.com/sonata-project/SonataAdminBundle/blob/3.0.0/composer.json) (and the bundle probably won't run on S4?)