### PR TITLE
Fix synonyms list field value

### DIFF
--- a/src/Zicht/Bundle/SolrBundle/Admin/SynonymAdmin.php
+++ b/src/Zicht/Bundle/SolrBundle/Admin/SynonymAdmin.php
@@ -51,7 +51,14 @@ class SynonymAdmin extends Admin
     {
         $listMapper
             ->addIdentifier('identifier')
-            ->add('value', null, ['label' => 'list.label_synonyms'])
+            ->add(
+                'value',
+                null,
+                [
+                    'label' => 'list.label_synonyms',
+                    'template' => 'ZichtSolrBundle:CRUD:list_multiline-multivalue.html.twig',
+                ]
+            )
             ->add('managed')
             ->add(
                 '_action',

--- a/src/Zicht/Bundle/SolrBundle/Resources/views/CRUD/list_multiline-multivalue.html.twig
+++ b/src/Zicht/Bundle/SolrBundle/Resources/views/CRUD/list_multiline-multivalue.html.twig
@@ -1,0 +1,5 @@
+{% extends get_admin_template('base_list_field', admin.code) %}
+
+{%- block field -%}
+    {{- value|replace({"\n": ', '}) -}}
+{%- endblock -%}


### PR DESCRIPTION
De waarden waren new line gescheiden, wat in HTML in de weergave een spatie oplevert. Er was geen verschil te zien tussen meerdere synoniemen en synoniemen met een spatie er in. Nu wordt er een komma gescheiden lijst getoond.