### PR TITLE
Replaced Guzzle base_url config parameter with the official base_uri parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 Nothing so far
 
+## 4.2.6 - 2020-04-28
+### Fixed
+- Changed use of Guzzle base_url config parameter into the official base_uri parameter
+
 ## 4.2.5 - 2020-04-20
 ### Fixed
 - Merged in v3.4.6: Catch NotFound exceptions when deleting Synonyms or stopwords and some minor cleanups

--- a/src/Zicht/Bundle/SolrBundle/DependencyInjection/ZichtSolrExtension.php
+++ b/src/Zicht/Bundle/SolrBundle/DependencyInjection/ZichtSolrExtension.php
@@ -32,7 +32,7 @@ class ZichtSolrExtension extends Extension
         }
 
         $container->getDefinition('zicht_solr.http_client')->setArguments([
-            ['base_url' => sprintf('http://%s:%d%s/%s/', $config['host'], $config['port'], $config['path'], $config['core'])],
+            ['base_uri' => sprintf('http://%s:%d%s/%s/', $config['host'], $config['port'], $config['path'], $config['core'])],
         ]);
         $container->setParameter('zicht_solr.managed', $config['managed']);
         $container->setParameter('zicht_solr.absolute_base_url', sprintf('http://%s:%d%s/', $config['host'], $config['port'], $config['path']));

--- a/src/Zicht/Bundle/SolrBundle/Solr/QueryBuilder/Ping.php
+++ b/src/Zicht/Bundle/SolrBundle/Solr/QueryBuilder/Ping.php
@@ -19,6 +19,6 @@ class Ping implements RequestBuilderInterface
      */
     public function createRequest(ClientInterface $httpClient)
     {
-        return new Request('GET', sprintf('%sadmin/ping', $httpClient->getConfig('base_url')));
+        return new Request('GET', sprintf('%sadmin/ping', $httpClient->getConfig('base_uri')));
     }
 }

--- a/src/Zicht/Bundle/SolrBundle/Solr/QueryBuilder/Select.php
+++ b/src/Zicht/Bundle/SolrBundle/Solr/QueryBuilder/Select.php
@@ -122,7 +122,7 @@ class Select extends AbstractQueryBuilder implements ResponseHandlerInterface
      */
     public function createRequest(ClientInterface $httpClient)
     {
-        return new Request('GET', sprintf('%sselect?%s', $httpClient->getConfig('base_url'), $this->createQueryString($this->params)));
+        return new Request('GET', sprintf('%sselect?%s', $httpClient->getConfig('base_uri'), $this->createQueryString($this->params)));
     }
 
     /**

--- a/src/Zicht/Bundle/SolrBundle/Solr/QueryBuilder/Update.php
+++ b/src/Zicht/Bundle/SolrBundle/Solr/QueryBuilder/Update.php
@@ -140,7 +140,7 @@ class Update extends AbstractQueryBuilder
         fseek($this->stream, 0);
         return new Request(
             'POST',
-            sprintf('%supdate', $httpClient->getConfig('base_url')),
+            sprintf('%supdate', $httpClient->getConfig('base_uri')),
             ['Content-Type' => 'application/json'],
             \GuzzleHttp\Psr7\stream_for($this->stream)
         );


### PR DESCRIPTION
`base_url` parameter has been renamed to `base_uri` in Guzzle 6.

This has always been working because the Guzzle config is just a simple array taking anything in and `getConfig()` returns it back to you. The official parameter in Guzzle 6 for this is `base_uri`. So when making a request without a full URL specified, there is no `base_uri` to fall back to. Also when you do want to instantiate Guzzle with the official `base_uri` parameter, then the Solr Client won't make the correct requests resulting in 404 errors from Solr.

:heavy_check_mark: With `base_uri` in Guzzle 6:
```php
object(Zicht\Bundle\SolrBundle\Solr\Client)
  private 'http' => 
    object(GuzzleHttp\Client)
      private 'config' => 
        array (size=9)
          'base_uri' => 
            object(GuzzleHttp\Psr7\Uri)
              private 'scheme' => string 'http' (length=4)
              private 'userInfo' => string '' (length=0)
              private 'host' => string 'solr' (length=4)
              private 'port' => int 8983
              private 'path' => string '/solr/core' (length=10)
              private 'query' => string '' (length=0)
              private 'fragment' => string '' (length=0)
          'handler' => 
            object(GuzzleHttp\HandlerStack)
                  ...
          ...
```

:x: With `base_url` in Guzzle 6:
```php
object(Zicht\Bundle\SolrBundle\Solr\Client)
  private 'http' => 
    object(GuzzleHttp\Client)
      private 'config' => 
        array (size=9)
          'base_url' => string 'http://solr:8983/solr/core' (length=26)
          'handler' => 
            object(GuzzleHttp\HandlerStack)
                  ...
          ...
```