### PR TITLE
Added DeleteIndexableRelationsInterface to be able to delete related entities in solr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added|Changed|Deprecated|Removed|Fixed|Security
-Nothing so far
+- Nothing so far
+
+## 3.5.0 - 2020-06-08
+### Added
+- Added DeleteIndexableRelationsInterface to be able to delete related entities in solr
 
 ## 3.4.10 - 2020-05-18
 ### Changed

--- a/src/Zicht/Bundle/SolrBundle/Manager/DeleteIndexableRelationsInterface.php
+++ b/src/Zicht/Bundle/SolrBundle/Manager/DeleteIndexableRelationsInterface.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @copyright Zicht Online <https://zicht.nl>
+ */
+
+namespace Zicht\Bundle\SolrBundle\Manager;
+
+/**
+ * Interface to indicate that the object has related objects that need to be deleted.
+ *
+ * @see \Zicht\Bundle\SolrBundle\Manager\SolrEntityManager
+ */
+interface DeleteIndexableRelationsInterface
+{
+    /**
+     * Should return an array of objects which should be deleted along with or instead of this object
+     *
+     * @return object[]
+     */
+    public function getDeleteIndexableRelations();
+}

--- a/src/Zicht/Bundle/SolrBundle/Manager/SolrEntityManager.php
+++ b/src/Zicht/Bundle/SolrBundle/Manager/SolrEntityManager.php
@@ -153,7 +153,16 @@ class SolrEntityManager extends SolrManager
         // Even if deletion failed (e.g. no mapper found) still update the relations
         if ($entity instanceof IndexableRelationsInterface) {
             foreach ($entity->getIndexableRelations() as $relation) {
+                if (in_array(spl_object_hash($entity), $this->deletedEntityHashes)) {
+                    continue;
+                }
                 $this->update($relation);
+            }
+        }
+
+        if ($entity instanceof DeleteIndexableRelationsInterface) {
+            foreach ($entity->getDeleteIndexableRelations() as $deleteRelation) {
+                $this->delete($deleteRelation);
             }
         }
 


### PR DESCRIPTION
In case of cascade delete, related entities need to be deleted in Solr.
(Created together with @7ochem )

Before merging, the CHANGELOG will be updated