### PR TITLE
Fix crontab false positives

### DIFF
--- a/src/Zicht/Bundle/SolrBundle/Command/ReindexCommand.php
+++ b/src/Zicht/Bundle/SolrBundle/Command/ReindexCommand.php
@@ -11,6 +11,7 @@ use \Symfony\Component\Console\Input\InputArgument;
 use \Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use \Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use \Zicht\Bundle\SolrBundle\Manager\Doctrine\SearchDocumentRepositoryAdapter;
 use \Zicht\Bundle\SolrBundle\Manager\Doctrine\SearchDocumentRepository;
 
@@ -42,6 +43,8 @@ class ReindexCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $output = new SymfonyStyle($input, $output);
+
         /** @var $solr \Zicht\Bundle\SolrBundle\Manager\SolrManager */
         $solr = $this->getContainer()->get('zicht_solr.manager');
         $solr->disableTimeout();


### PR DESCRIPTION
Hierdoor hoeven we de `zicht:solr:reindex` niet meer met `--quiet` te draaien.  I.e. de progress bar output gaat nu naar stdout ipv altijd naar stderr.

Dit gaan we **niet** forward mergen naar versies 3, 4, en 5.  Deze zijn niet compatible.  Verder heeft deze versie ook geen changelog, vandaar dat daar ook geen aanpassing in is gemaakt (dit is super oud allemaal)

Alvast getagged met 2.8.2