### PR TITLE
Fix Entity Mapper generated object ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-.idea/
+/composer.lock
+/.idea/
 /vendor/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 Nothing so far
 
+## 5.0.5 - 2021-10-25
+### Fixed
+- Added an override of generateObjectIdentity() to the EntityMapper to fix classnames when the entity is a Doctrine proxy
+
 ## 5.0.4 - 2021-05-17
 ### Fixed
 - Changed left overs of Guzzle 5 into Guzzle 6 in Synonym and Stopword code

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "require": {
         "php": "^7.1",
+        "doctrine/common": "^2.2 || ^3",
         "guzzlehttp/guzzle": "^6.3",
         "sonata-project/admin-bundle": "^3",
         "symfony/console": "^3.4 || ^4.4"

--- a/src/Manager/Doctrine/EntityMapper.php
+++ b/src/Manager/Doctrine/EntityMapper.php
@@ -5,6 +5,7 @@
 
 namespace Zicht\Bundle\SolrBundle\Manager\Doctrine;
 
+use Doctrine\Common\Util\ClassUtils;
 use Zicht\Bundle\SolrBundle\Manager\AbstractDataMapper;
 
 /**
@@ -15,4 +16,18 @@ use Zicht\Bundle\SolrBundle\Manager\AbstractDataMapper;
  */
 abstract class EntityMapper extends AbstractDataMapper
 {
+    /**
+     * Doctrine might create a proxy class for an entity. We need the real classname, otherwise the Solr ID might differ
+     * from mapping the entity without proxy class and the same data will be in the Solr index twice.
+     * ClassUtils::getRealClass() will strip off the proxy namespace.
+     * {@inheritDoc}
+     */
+    protected function generateObjectIdentity($entity)
+    {
+        if (method_exists($entity, 'getId')) {
+            return sha1(ClassUtils::getClass($entity) . ':' . $entity->getId());
+        }
+
+        return parent::generateObjectIdentity($entity);
+    }
 }


### PR DESCRIPTION
Doctrine could generate proxy classes for entities, see `var/cache/*/doctrine/orm/Proxies/`:

```
$ ls -1 var/cache/dev/doctrine/orm/Proxies/
__CG__AppEntityPageContentPage.php
__CG__AppEntityTerm.php
__CG__ZichtBundleDynamicFormsBundleEntityForm.php
__CG__ZichtBundleMenuBundleEntityMenuItem.php
```

The namespace of these classes is being prefixed with `Proxies\__CG__\` so if you call `get_class` on an entiteit object, then you could get different results:

```
var_dump(get_class($contentPage));
string(27) "App\Entity\Page\ContentPage"
// vs.
var_dump(get_class($contentPage));
string(27) "Proxies\__CG__\App\Entity\Page\ContentPage"
```

So if you are going to use `get_class($entity)` as input for generating a hash, then there will also be two different results for normal vs. proxy objects. Doctrine's `ClassUtils::getClass()` will always give us the original class.
