### PR TITLE
Fix Solr Manager FQCN service aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 Nothing so far
 
+## 5.0.7 - 2022-05-12
+### Fixed
+- Point Solr Manager FQCN service aliases to the `zicht_solr.manager` service after having determined which Manager to use
+
 ## 5.0.6 - 2022-03-30
 ### Fixed
 - Fixed use of old/deprecated Sensio Route and Doctrine Registry

--- a/src/DependencyInjection/ZichtSolrExtension.php
+++ b/src/DependencyInjection/ZichtSolrExtension.php
@@ -9,13 +9,12 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Zicht\Bundle\SolrBundle\Manager\SolrEntityManager;
+use Zicht\Bundle\SolrBundle\Manager\SolrManager;
 
 class ZichtSolrExtension extends Extension
 {
-    /**
-     * {@inheritDoc}
-     */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
@@ -29,7 +28,11 @@ class ZichtSolrExtension extends Extension
             $container->setDefinition('zicht_solr.manager', clone $container->getDefinition('zicht_solr.manager.default_manager'));
         } else {
             $container->setDefinition('zicht_solr.manager', clone $container->getDefinition('zicht_solr.manager.entity_manager'));
+            $container->removeAlias(SolrEntityManager::class);
+            $container->setAlias(SolrEntityManager::class, 'zicht_solr.manager');
         }
+        $container->removeAlias(SolrManager::class);
+        $container->setAlias(SolrManager::class, 'zicht_solr.manager');
 
         $solrArguments = $container->getDefinition('zicht_solr.solr')->getArguments();
         $solrArguments[0] = $config;


### PR DESCRIPTION
I wanted to inject the SolrManager by autowiring and found that it had no mappers set to it. `\Zicht\Bundle\SolrBundle\DependencyInjection\CompilerPass\AddMapperPass` is responsible for calling `addMapper()` for each mapper found tagged with `'zicht_solr.mapper'`. It does so on the `'zicht_solr.manager'` service definition. So that service definition should also be referenceable by `\Zicht\Bundle\SolrBundle\Manager\SolrManager`