### PR TITLE
Fix deprecation fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 Nothing so far
 
-## 5.0.7 - 2022-05-12
+## 5.0.8 - 2022-05-02
+### Fixed
+- Changed use of deprecated Sonata Admin class into AbstractAdmin class
+- Fixed usage of deprecated Twig template colon path and changed into modern path
+- Fixed select command
+- Changed use of deprecated `->setHelps()` to setting `'help'` on the field itself for the
+  Sonata Synonym admin
+
+## 5.0.7 - 2022-04-12
 ### Fixed
 - Point Solr Manager FQCN service aliases to the `zicht_solr.manager` service after having determined which Manager to use
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.1",
         "doctrine/common": "^2.2 || ^3",
         "guzzlehttp/guzzle": "^6.3",
-        "sonata-project/admin-bundle": "^3",
+        "sonata-project/admin-bundle": "^3.74",
         "symfony/console": "^3.4 || ^4.4"
     },
     "autoload": {

--- a/src/Admin/StopWordAdmin.php
+++ b/src/Admin/StopWordAdmin.php
@@ -5,17 +5,18 @@
 
 namespace Zicht\Bundle\SolrBundle\Admin;
 
-use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Route\RouteCollection;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Zicht\Bundle\SolrBundle\Entity\StopWord;
 
 /**
- * Class StopWordAdmin
+ * @extends AbstractAdmin<StopWord>
  */
-class StopWordAdmin extends Admin
+class StopWordAdmin extends AbstractAdmin
 {
     /**
      * {@inheritDoc}

--- a/src/Admin/SynonymAdmin.php
+++ b/src/Admin/SynonymAdmin.php
@@ -5,7 +5,7 @@
 
 namespace Zicht\Bundle\SolrBundle\Admin;
 
-use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
@@ -15,9 +15,9 @@ use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Zicht\Bundle\SolrBundle\Entity\Synonym;
 
 /**
- * Class SynonymAdmin
+ * @extends AbstractAdmin<Synonym>
  */
-class SynonymAdmin extends Admin
+class SynonymAdmin extends AbstractAdmin
 {
     /**
      * {@inheritDoc}
@@ -57,7 +57,7 @@ class SynonymAdmin extends Admin
                 null,
                 [
                     'label' => 'list.label_synonyms',
-                    'template' => 'ZichtSolrBundle:CRUD:list_multiline-multivalue.html.twig',
+                    'template' => '@ZichtSolr/CRUD/list_multiline-multivalue.html.twig',
                 ]
             )
             ->add('managed')
@@ -83,14 +83,10 @@ class SynonymAdmin extends Admin
             ->tab('admin.tab.general')
                 ->add('managed', ChoiceType::class, $this->getManagedFieldOptions())
                 ->add('identifier')
-                ->add('value', TextareaType::class)
+                ->add('value', TextareaType::class, ['help' => $this->trans('help.synonyms', [], 'admin')])
                 ->end()
             ->end()
         ;
-
-        $formMapper->setHelps([
-            'value' => $this->trans('help.synonyms', [], 'admin')
-        ]);
     }
 
     /**

--- a/src/Command/SelectCommand.php
+++ b/src/Command/SelectCommand.php
@@ -92,8 +92,10 @@ class SelectCommand extends AbstractCommand
             $select->setStart($start);
         }
         $results = $this->solr->select($select)->response->docs;
-        if ($output->getVerbosity() > 0) {
-            $output->writeln($this->solr->getLastResponse()->getEffectiveUrl() . PHP_EOL. PHP_EOL);
+        if ($output->getVerbosity() >= Console\Output\OutputInterface::VERBOSITY_VERBOSE) {
+            $output->writeln(sprintf('<info>%s %s</info>', $this->solr->getLastResponse()->getReasonPhrase(), $this->solr->getLastRequest()->getUri()));
+            $output->writeln(sprintf('<info>%d result(s)</info>', count($results)));
+            $output->writeln('');
         }
         foreach ($results as $doc) {
             $output->writeln(json_encode($doc, JSON_PRETTY_PRINT));

--- a/src/Resources/views/DataCollector/data_collector.html.twig
+++ b/src/Resources/views/DataCollector/data_collector.html.twig
@@ -1,10 +1,10 @@
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block toolbar %}
     {% set icon %}
         <a href="{{ path('_profiler', { 'token': token, 'panel': name }) }}">
             <span>
-                <span class="icon">{{ include('@ZichtSolrBundle/Resources/public/images/solr_icon.svg') }}</span>
+                <span class="icon"><img src="{{ asset('bundles/zichtsolr/images/solr_icon.svg') }}" /></span>
                 <span class="sf-toolbar-status">{{ collector.requests|length }}</span>
             </span>
         </a>
@@ -26,9 +26,7 @@
 {% block menu %}
     {# This left-hand menu appears when using the full-screen profiler. #}
     <span class="label">
-        <span class="icon">
-            {{ include('@ZichtSolrBundle/Resources/public/images/solr_icon.svg') }}
-        </span>
+        <span class="icon"><img src="{{ asset('bundles/zichtsolr/images/solr_icon.svg') }}" /></span>
         <strong>Solr Requests</strong><span class="count">{{ collector.requests|length }}</span>
     </span>
 {% endblock %}


### PR DESCRIPTION
### Fixed
- Changed use of deprecated Sonata Admin class into AbstractAdmin class
- Fixed usage of deprecated Twig template colon path and changed into modern path
- Fixed select command
- Changed use of deprecated `->setHelps()` to setting `'help'` on the field itself for the
  Sonata Synonym admin