### PR TITLE
Reindex command improvements

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-22.04
         strategy:
             matrix:
-                php: [ '7.4', '8.0', '8.1' ]
+                php: [ '7.4', '8.0', '8.1', '8.2' ]
         name: PHP ${{ matrix.php }}
         steps:
             -   uses: actions/checkout@v3
@@ -25,6 +25,6 @@ jobs:
             -   run: composer config -g github-oauth.github.com ${{ secrets.GITHUB_TOKEN }}
             -   run: composer install --prefer-dist --no-progress --no-scripts
             -   if: always()
-                run: composer run-script analysis -- --no-suggestions --output-format=github
+                run: composer run-script analysis -- --php-version=${{ matrix.php }} --no-suggestions --output-format=github
             -   if: always()
                 run: composer run-script test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 - Nothing so far
 
+## 6.2.0 - 2023-02-22
+### Added
+- Reset PHP's memory peak usage in between reindexing of entities (PHP >= 8.2).
+- Duration time and byte size information in reindex command.
+- Added explicit max. memory of 50 Mb to the temp stream of the Solr update query,
+  instead of relying on the (2 Mb) default.
+### Fixed
+- Improved texts and text colors of reindex command output.
+
 ## 6.1.1 - 2023-02-20
 ### Fixed
 - Forward merge of 4.3.1

--- a/src/Solr/QueryBuilder/Update.php
+++ b/src/Solr/QueryBuilder/Update.php
@@ -14,6 +14,8 @@ use Zicht\Bundle\SolrBundle\Solr\DateHelper;
  */
 class Update extends AbstractQueryBuilder
 {
+    private const STREAM_MAX_MEMORY = 50 * 1048576; // 50 Mb, default is 2 Mb
+
     private $stream = null;
 
     /**
@@ -21,7 +23,7 @@ class Update extends AbstractQueryBuilder
      */
     public function __construct()
     {
-        $this->stream = fopen('php://temp', 'rw');
+        $this->stream = fopen(sprintf('php://temp/maxmemory:%s', self::STREAM_MAX_MEMORY), 'rw');
         fwrite($this->stream, '{');
     }
 
@@ -138,5 +140,10 @@ class Update extends AbstractQueryBuilder
             ['Content-Type' => 'application/json'],
             \GuzzleHttp\Psr7\stream_for($this->stream)
         );
+    }
+
+    public function getQueryByteSize(): int
+    {
+        return fstat($this->stream)['size'];
     }
 }


### PR DESCRIPTION
```markdown
## 6.2.0 - 2023-02-22
### Added
- Reset PHP's memory peak usage in between reindexing of entities (PHP >= 8.2).
- Duration time and byte size information in reindex command.
- Added explicit max. memory of 50 Mb to the temp stream of the Solr update query,
  instead of relying on the (2 Mb) default.
### Fixed
- Improved texts and text colors of reindex command output.
```

Before:
![Screenshot from 2023-02-21 10-55-55](https://user-images.githubusercontent.com/2794908/220317122-0962917a-6cc2-45bb-b1be-53617dbc2901.png)

After:
![Screenshot from 2023-02-21 10-56-08](https://user-images.githubusercontent.com/2794908/220317149-3d73654b-b2a3-40c4-bae2-f674ec80bf57.png)
