### PR TITLE
Fix synonym admin value label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 - Nothing so far
 
+## 6.2.1 - 2023-05-11
+### Fixed
+- Synonym admin value label
+
 ## 6.2.0 - 2023-03-09
 ### Added
 - Reset PHP's memory peak usage in between reindexing of entities (PHP >= 8.2).

--- a/src/Admin/SynonymAdmin.php
+++ b/src/Admin/SynonymAdmin.php
@@ -69,7 +69,7 @@ class SynonymAdmin extends AbstractAdmin
             ->tab('admin.tab.general')
                 ->add('managed', ChoiceType::class, $this->getManagedFieldOptions())
                 ->add('identifier')
-                ->add('value', TextareaType::class, ['help' => $this->trans('help.synonyms', [], 'admin')])
+                ->add('value', TextareaType::class, ['label' => 'form.label_synonyms', 'help' => $this->trans('help.synonyms', [], 'admin')])
                 ->end()
             ->end();
     }

--- a/src/Resources/translations/admin.en.yml
+++ b/src/Resources/translations/admin.en.yml
@@ -22,7 +22,7 @@ form:
     label_managed: Managed
     label_identifier: Word
     label_stop_word: Stop word
-    label_value: Synonyms
+    label_synonyms: Synonyms
 
 list:
     label_identifier: Word

--- a/src/Resources/translations/admin.nl.yml
+++ b/src/Resources/translations/admin.nl.yml
@@ -22,7 +22,7 @@ form:
     label_managed: Managed
     label_identifier: Woord
     label_stop_word: Stopwoord
-    label_value: Synoniemen
+    label_synonyms: Synoniemen
 
 list:
     label_identifier: Woord


### PR DESCRIPTION
"value" is a quite generic label, so maybe we shouldn't translate that to "Synonyms"